### PR TITLE
Adds comments

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -61,6 +61,13 @@ class Downloader():
         return self
     
     @staticmethod
+    # COMMENT: Having a subprocess works quite good
+    # I looked at python solutions, they all seem to need
+    # unrar.exe to be in the path anyway
+    # For linux, if unrar is not installed subprocess will fail.
+    # I would suggest to use .zip files instead and then install
+    # the zipfile package (which is a python package)
+    # so no external calls are needed
     def _unrar(path, folder=SOURCE_CSV_DIR):        
         subprocess.check_call([
             UNPACK_RAR_EXE,
@@ -115,7 +122,10 @@ def get_csv_lines(filename=SOURCE_CSV_PATH, cols=COLNAMES):
 #   Manipulate labels
 #           
 #            
-               
+
+# COMMENT: This logic here is used to initialize the OUTPUT_CSV_COLUMNS
+# but is a bit confusing - perhaps it can be put in a function, like:
+# OUPUT_CSV_COLUMNS = generate_output_csv_columns()
 data_fields = [x[0:-1] for x in current]
 data_labels = current+prev
 new = ['year'] + OKVED_KEYS + ['region', 'org', 'title']   
@@ -130,6 +140,10 @@ OUTPUT_CSV_COLUMNS = new + firm + data_fields
 #           
 # 
 
+# COMMENT: I suppose here you are not using pandas because of memory concerns?
+# Because getting the rows as dictionaries is very easy in a pandas DataFrame
+
+
 def lines_as_dicts(filename=SOURCE_CSV_PATH, cols=COLNAMES, year=YEAR, 
                    yield_previous_year=False):
                        
@@ -137,6 +151,9 @@ def lines_as_dicts(filename=SOURCE_CSV_PATH, cols=COLNAMES, year=YEAR,
 
     unit_multipliers={'383':0.001, '384':1, '385':1000}
     
+    # COMMENT: Here, prev and current looks like it's a variable, whereas it's really a constant 
+    # imported from a module. You can rename to PREV_YEAR_INDEX and CURR_YEAR_INDEX (or something else
+    # that is an informative name)
     if yield_previous_year:
         year=year-1
         ix = prev
@@ -170,6 +187,13 @@ def lines_as_dicts(filename=SOURCE_CSV_PATH, cols=COLNAMES, year=YEAR,
         yield r
 
 
+# COMMENT:
+# I would rename this to: output_to_csv
+# COMMENT:
+# Reading/Writing the data one row at a time is good for memory usage
+# But there's a hybrid solution where you read N lines and write N lines together
+# which can have better performance (because writing takes the same time if you write a small chunk of a data
+# vs a slightly bigger one. So, if writing takes a lot of time, writing multiple rows at once is something to consider
 def to_csv(gen, filename, folder=SOURCE_CSV_DIR, cols=OUTPUT_CSV_COLUMNS):
     path = os.path.join(folder, filename)
     with open(path, 'w', encoding = "utf-8") as output_file:    
@@ -182,6 +206,8 @@ def to_csv(gen, filename, folder=SOURCE_CSV_DIR, cols=OUTPUT_CSV_COLUMNS):
 
 
 if __name__=="__main__":
+    # COMMENT: This is the entrypoint to the whole thing. I would actually put explicitly in the keyword arguments
+    # because without them it's not clear what you are getting and where you are saving it
     Downloader(SOURCE_URL).download().unrar()
     to_csv(gen=lines_as_dicts(), filename="all2013.csv")   
     to_csv(gen=lines_as_dicts(yield_previous_year=True), filename="all2012.csv")

--- a/slicer.py
+++ b/slicer.py
@@ -7,6 +7,8 @@ from column_names import colname_to_varname_dict as SUB
 NON_MONETARY_COLUMNS = ['inn', 'year', 'okved1', 'region', 'title']
 MY_COLS = NON_MONETARY_COLUMNS + [x for x in SUB.keys()]
 
+# COMMENT: In this file it would help to have docstrings in the methods to explain what they do
+
 def shorten(df, new_colnames=MY_COLS, replace_colnames_dict=SUB):
     return df[new_colnames].rename(columns=replace_colnames_dict)
 
@@ -23,7 +25,11 @@ def flags(df):
 def check_balance(df, treshold = 0.1):
     for flag in flags(df):
         assert flag < treshold
+        # COMMENT: Here can also do:
+        # if flag>=threshold:
+        #   raise Exception("Flag {} >= threshold {}".format(flag, threshold))
             
+# COMMENT: fileds -> typo
 def _extract_fileds_from_compact_df(compact_df_prev, fields = ['sales', 'of']):
     sub = {x:x+"_prev" for x in fields} 
     df2 = compact_df_prev[fields].rename(columns=sub)
@@ -46,11 +52,16 @@ def make_main():
     merged_df.to_csv("data/merged.csv", sep = ";", index = False, encoding = "utf-8")
     
 if __name__ == "__main__":
+    # COMMENT: If this is where the memory crashes, consider reading the file in chunks
+    # first answer on here:
+    # http://stackoverflow.com/questions/31765123/pandas-dataframe-merge-memoryerror
     df = pd.read_csv("data/all2013.csv", sep = ";")
     renamed_df = shorten(df)  
     
     # add fields from previous year
     df2 = get_prev_compact_df()
+    # COMMENT: If this is where the memory crashes, perhaps setting inn as the index can help.
+    # If not, we can indeed look into sql solutions (they will still need indexes on inn for sure though)
     merged_df = renamed_df.merge(df2, on='inn')
     
     merged_df.to_csv("data/merged.csv", sep = ";", index = False, encoding = "utf-8")


### PR DESCRIPTION
Created a pull request to show inline comments, you don't need to merge. 

Some high level comments:

- If at the end (in slicer.py) you use pandas to load the intermediate csvs (so to load them in memory all at once), then it's not clear to me what benefit you get by writing functions to read the initial csvs line by line in reader.py.

- Default arguments are good, but it makes it hard to follow what's happening when the functions are called from main without any explicit arguments. I would take the time to write them out explicitly. That way when you say, ```output = "foo.csv"```, you can reuse this variable when you need to read this output file, and not have to remember to put the same default argument in both the writer and the reader.

- Related to the previous point: It looks like the process has only a few steps. I would not use luigi for that, I would just make sure that the output of the reader.py step is fed into the slicer.py directly

- A public dropbox link is a fine alternative for providing the data for download

- It would help me for our session next week if you share more information about how long this takes to run, for what size of files

